### PR TITLE
TCI-1262: add support for scale param for point image sprites

### DIFF
--- a/src/OpenGl/OpenGl_PrimitiveArray.cxx
+++ b/src/OpenGl/OpenGl_PrimitiveArray.cxx
@@ -604,7 +604,9 @@ void OpenGl_PrimitiveArray::drawMarkers (const Handle(OpenGl_Workspace)& theWork
   if (anAspectMarker->HasPointSprite (aCtx))
   {
     // Textured markers will be drawn with the point sprites
-    aCtx->SetPointSize (anAspectMarker->MarkerSize());
+    // Apply the scale for point image sprites as well, because sometimes we need it, for example to
+    // scale on retina displays with the device pixel ratio
+    aCtx->SetPointSize (anAspectMarker->MarkerSize() * anAspectMarker->Aspect()->MarkerScale());
     aCtx->SetPointSpriteOrigin();
 
     aCtx->core11fwd->glDrawArrays (aDrawMode, 0, !myVboAttribs.IsNull() ? myVboAttribs->GetElemsNb() : myAttribs->NbElements);


### PR DESCRIPTION
- apply scale for the sprites created with the original image size
- sometimes we need it for retina displays